### PR TITLE
[FIX] Improved security for import output to protect against XSS

### DIFF
--- a/Resources/Private/FusionModule/Components/ImportProtocol.fusion
+++ b/Resources/Private/FusionModule/Components/ImportProtocol.fusion
@@ -20,9 +20,9 @@ prototype(Neos.RedirectHandler.Ui:Component.ImportProtocol) < prototype(Neos.Fus
                         <i class="fas fa-equals" @if.type={entry.type == 'unchanged'}></i>
                     </td>
                     <td class={props.className + '-entry__label'}>
-                        {entry.message}
+                        {String.htmlSpecialChars(entry.message)}
                         <span @if.hasRedirect={entry.redirect}>
-                            {entry.redirect.host}/{entry.redirect.sourceUriPath} &rarr; {entry.redirect.targetUriPath} ({entry.redirect.statusCode})
+                            {String.htmlSpecialChars(entry.redirect.host)}/{String.htmlSpecialChars(entry.redirect.sourceUriPath)} &rarr; {String.htmlSpecialChars(entry.redirect.targetUriPath)} ({String.htmlSpecialChars(entry.redirect.statusCode)})
                         </span>
                     </td>
                     <td>
@@ -37,7 +37,7 @@ prototype(Neos.RedirectHandler.Ui:Component.ImportProtocol) < prototype(Neos.Fus
                     </td>
                     <td title={entry.redirect.comment}>
                         <span @if.comment={entry.redirect.comment}>
-                            {String.crop(entry.redirect.comment, 25, '&#8230;') || '&ndash;'}
+                            {String.crop(String.htmlSpecialChars(entry.redirect.comment), 25, '&#8230;') || '&ndash;'}
                         </span>
                     </td>
                 </tr>


### PR DESCRIPTION
In this commit, I've addressed a security concern related to the redirect import feature. Specifically, I've taken measures to eliminate a reflected cross-site scripting (XSS) vulnerability in the "import protocol" output.
 
In simple terms, I've added String.htmlSpecialChrars() to ensure that any user-generated data is now thoroughly encoded. This significantly minimizes the risk of malicious scripts being executed through the output.

If you have any questions about this commit or want more information about the changes, feel free to reach out to me. Your feedback and suggestions are always appreciated!